### PR TITLE
Fixes error on obj var for unexpected ";" at column 4

### DIFF
--- a/wetransfer.py
+++ b/wetransfer.py
@@ -45,8 +45,12 @@ request_data = requests.get(url)
 soup = BeautifulSoup(request_data.text, "html.parser")
 for script_tag in soup.select('script[type="text/javascript"]'):
     if "__launch_darkly" in script_tag.string and "feature_flags" in script_tag.string:
-        js_src = script_tag.string.strip().rstrip(";")
-        obj_src = js_src[js_src.find("{") :]
+        js_src = script_tag.string.strip()
+        var_start = js_src.find("__launch_darkly")
+        var_src_junk = js_src[var_start:]
+        var_end = var_src_junk.find(";")
+        var_src = var_src_junk[:var_end]
+        obj_src = var_src[var_src.find("{"):].strip().strip(";")
         obj = json5.loads(obj_src)
         domain_user_id = obj["user"]["key"]
         break


### PR DESCRIPTION
Hi,

WeTransfer now has three variables in the script element that holds the `__launch_darkly__` variable, and that causes the error below:

![Group 1(19)](https://user-images.githubusercontent.com/533273/191937753-34588222-25f0-4f32-b767-e3caaaa35c9e.png)


```bash
Traceback (most recent call last):
  File "wetransfer.py", line 50, in <module>
    obj = json5.loads(obj_src)
  File "/opt/hostedtoolcache/Python/3.10.6/x64/lib/python3.10/site-packages/json5/lib.py", line 81, in loads
    raise ValueError(err)
ValueError: <string>:6 Unexpected ";" at column 4
```

This PR isolates that variable before loading it as JSON.

Obs: I'm not a Python developer.